### PR TITLE
Fix Max Heap Size for Tomcat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,7 @@ RUN chown -R tomcat:tomcat "/var/lib/tomcat9/" \
     && chown -R tomcat:tomcat "/usr/local/src/"
 
 #CSet up OS
+RUN echo 'JAVA_OPTS="-Xmx2048m"' > /usr/share/tomcat9/bin/setenv.sh
 RUN sed -i -r 's/^(JAVA_OPTS=.*)"/\1 -Xmx2048m"/' "/etc/default/tomcat9"
 RUN printf "[Service]\n%s\n" "ReadWritePaths=/var/lib/openspecimen/" > "/etc/systemd/system/tomcat9.service.d/openspecimen.conf"
 


### PR DESCRIPTION
When running on Windows using WSL, I was getting this error message:

```
local-openspecimen-web  |  ***************************************************
local-openspecimen-web  |  OpenSpecimen, a Krishagni Product
local-openspecimen-web  |  Build Version :
local-openspecimen-web  |  Build Date    : Thu Apr 18 15:25:37 UTC 2024
local-openspecimen-web  |  Commit        :
local-openspecimen-web  |  Present Time  : Fri Apr 19 12:37:43 UTC 2024
local-openspecimen-web  |  Max. Heap Size: 1.91 GB
local-openspecimen-web  |  ***************************************************
local-openspecimen-web  |  ***************************************************
local-openspecimen-web  |  *        ERROR! ERROR!! ERROR!!!                  *
local-openspecimen-web  |  ***************************************************
local-openspecimen-web  |  OpenSpecimen is started using < 2GB heap size.
local-openspecimen-web  |  Minimum 2GB heap required.
local-openspecimen-web  |  Consider using -Xmx2048m option when starting Tomcat
local-openspecimen-web  |  Exiting
local-openspecimen-web  |  ***************************************************
```

This PR fixes this issue and it runs ok on Windows.